### PR TITLE
feat: make image upload size configurable

### DIFF
--- a/rapidocr_web/ocrweb.py
+++ b/rapidocr_web/ocrweb.py
@@ -15,13 +15,21 @@ except:
 root_dir = Path(__file__).resolve().parent
 
 app = Flask(__name__, template_folder="templates")
-app.config["MAX_CONTENT_LENGTH"] = 3 * 1024 * 1024
 processor = OCRWebUtils()
 
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    # Expose max upload size (in MB) to the frontend; 0 means unlimited
+    mcl = app.config.get("MAX_CONTENT_LENGTH", None)
+    if mcl is None:
+        max_upload_mb = 0
+    else:
+        try:
+            max_upload_mb = int(mcl // (1024 * 1024))
+        except Exception:
+            max_upload_mb = 0
+    return render_template("index.html", max_upload_mb=max_upload_mb)
 
 
 @app.route("/ocr", methods=["POST"])
@@ -36,7 +44,15 @@ def main():
     parser = argparse.ArgumentParser("rapidocr_web")
     parser.add_argument("-ip", "--ip", type=str, default="0.0.0.0", help="IP Address")
     parser.add_argument("-p", "--port", type=int, default=9003, help="IP port")
+    parser.add_argument("-m", "--max-content-length", type=int, default=3,
+                        help="Max upload size in MB. Set 0 for unlimited.")
     args = parser.parse_args()
+
+    # Configure MAX_CONTENT_LENGTH based on CLI argument
+    if args.max_content_length is None or args.max_content_length == 0:
+        app.config["MAX_CONTENT_LENGTH"] = None  # Unlimited
+    else:
+        app.config["MAX_CONTENT_LENGTH"] = int(args.max_content_length) * 1024 * 1024
 
     print(f"Successfully launched and visit http://{args.ip}:{args.port} to view.")
     server = make_server(args.ip, args.port, app)

--- a/rapidocr_web/templates/index.html
+++ b/rapidocr_web/templates/index.html
@@ -42,7 +42,14 @@
                         <i class="fas fa-cloud-upload-alt"></i>
                     </div>
                     <h3 class="upload-title">粘贴剪贴板图像、拖拽图片或点击上传</h3>
-                    <p class="upload-subtitle">支持 PNG、JPG、JPEG、BMP、WEBP 格式，文件大小不超过 3MB</p>
+                    <p class="upload-subtitle">
+                                            支持 PNG、JPG、JPEG、BMP、WEBP 格式，
+                                            {% if max_upload_mb and max_upload_mb > 0 %}
+                                            文件大小不超过 {{ max_upload_mb }}MB
+                                            {% else %}
+                                            文件大小不限制
+                                            {% endif %}
+                                        </p>
                     <button class="upload-btn" onclick="document.getElementById('rapid_ocr').click();">
                         <i class="fas fa-plus"></i>
                         选择图片
@@ -136,6 +143,7 @@
     <script src="{{url_for('static', filename='js/jquery-3.0.0.min.js')}}"></script>
     <script src="{{url_for('static', filename='js/app.js')}}"></script>
     <script type="text/javascript">
+        window.MAX_UPLOAD_MB = {{ max_upload_mb }};
         // 页面加载时，执行
         var targetFile = null;
         window.onload = function () {
@@ -225,8 +233,8 @@
 
             // 判断图像大小是否符合
             let imageSize = targetFile.size / 1024 / 1024;
-            if (imageSize >= 3) {
-                showNotification("图像大小超过3MB！", "error");
+            if (window.MAX_UPLOAD_MB && window.MAX_UPLOAD_MB > 0 && imageSize >= window.MAX_UPLOAD_MB) {
+                showNotification(`图像大小超过${window.MAX_UPLOAD_MB}MB！`, "error");
                 return;
             }
 


### PR DESCRIPTION
现在手机拍照很容易达到几十MB，默认的3MB限制太小了。
这个PR可以将默认的图片上传3MB限制改成可以动态配置。

```bash
# 默认还是3MB
python ocrweb.py
# 限制20MB
python ocrweb.py --max-content-length 20
# 不限制图片上传大小
python ocrweb.py --max-content-length 0
```